### PR TITLE
Add product search with filtering

### DIFF
--- a/frontend/pages/all-tools.tsx
+++ b/frontend/pages/all-tools.tsx
@@ -1,14 +1,82 @@
 import Link from 'next/link';
-import { Card } from 'magicui';
+import { Card, Input } from 'magicui';
 import type { Tool } from '../data/tools';
 import { tools } from '../data/tools';
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
 
 export default function AllTools() {
+  const router = useRouter();
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState('All');
+  const [openSource, setOpenSource] = useState('All');
+
+  useEffect(() => {
+    if (router.query.category) {
+      setCategory(router.query.category as string);
+    }
+    if (router.query.search) {
+      setSearch(router.query.search as string);
+    }
+    if (router.query.openSource) {
+      setOpenSource(router.query.openSource as string);
+    }
+  }, [router.query]);
+
+  const categories = useMemo(() => Array.from(new Set(tools.map(t => t.category))), []);
+
+  const filteredTools = tools.filter(tool => {
+    if (search && !tool.name.toLowerCase().includes(search.toLowerCase())) {
+      return false;
+    }
+    if (category !== 'All' && tool.category !== category) {
+      return false;
+    }
+    if (openSource === 'true' && !tool.openSource) {
+      return false;
+    }
+    if (openSource === 'false' && tool.openSource) {
+      return false;
+    }
+    return true;
+  });
+
   return (
     <main className="p-8 h-screen overflow-y-auto">
       <h1 className="text-2xl font-bold mb-4">All Tools</h1>
+
+      <div className="mb-4 flex flex-col sm:flex-row sm:items-end gap-4">
+        <Input
+          placeholder="Search by name"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="w-full sm:w-1/3"
+        />
+        <select
+          value={category}
+          onChange={e => setCategory(e.target.value)}
+          className="border p-2 rounded"
+        >
+          <option value="All">All Categories</option>
+          {categories.map(c => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <select
+          value={openSource}
+          onChange={e => setOpenSource(e.target.value)}
+          className="border p-2 rounded"
+        >
+          <option value="All">All</option>
+          <option value="true">Open Source</option>
+          <option value="false">Proprietary</option>
+        </select>
+      </div>
+
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {tools.map(tool => (
+        {filteredTools.map(tool => (
           <Card key={tool.id} className="p-4 border rounded">
             <h2 className="font-semibold mb-1">{tool.name}</h2>
             <p className="text-sm text-gray-600 mb-1">{tool.description}</p>
@@ -19,6 +87,7 @@ export default function AllTools() {
             </Link>
           </Card>
         ))}
+        {filteredTools.length === 0 && <p>No tools found.</p>}
       </div>
     </main>
   );

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,11 +1,35 @@
 import Link from 'next/link';
 import { Input, Button } from 'magicui';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
 
 export default function Home() {
+  const router = useRouter();
+  const [search, setSearch] = useState('');
+
+  const handleSearch = () => {
+    if (search.trim()) {
+      router.push(`/all-tools?search=${encodeURIComponent(search)}`);
+    } else {
+      router.push('/all-tools');
+    }
+  };
+
   return (
     <main className="p-8">
       <h1 className="text-2xl font-bold mb-4">SaaS Investigator</h1>
-      <Input placeholder="Search tools" className="mb-4 w-full" />
+      <div className="mb-4 flex gap-2">
+        <Input
+          placeholder="Search tools"
+          className="w-full"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') handleSearch();
+          }}
+        />
+        <Button onClick={handleSearch}>Search</Button>
+      </div>
       <div className="mt-4 space-x-2">
         <Link href="/tools?category=DevOps">
           <Button>DevOps</Button>

--- a/frontend/pages/tools/index.tsx
+++ b/frontend/pages/tools/index.tsx
@@ -2,14 +2,23 @@ import Link from 'next/link';
 import type { Tool } from '../../data/tools';
 import { tools } from '../../data/tools';
 import { Card } from 'magicui';
+import { useRouter } from 'next/router';
+import { useMemo } from 'react';
 
 export default function Tools() {
+  const router = useRouter();
+  const category = router.query.category as string | undefined;
+
+  const filteredTools = useMemo(() => {
+    if (!category) return tools;
+    return tools.filter(t => t.category === category);
+  }, [category]);
 
   return (
     <main className="p-8">
       <h1 className="text-2xl font-bold mb-4">Tools</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {tools.map(tool => (
+        {filteredTools.map(tool => (
           <Card key={tool.id} className="p-4 border rounded">
             <h2 className="font-semibold mb-1">{tool.name}</h2>
             <p className="text-sm text-gray-600 mb-1">{tool.description}</p>
@@ -20,6 +29,7 @@ export default function Tools() {
             </Link>
           </Card>
         ))}
+        {filteredTools.length === 0 && <p>No tools found.</p>}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- enable search with category and open source filters on the All Tools page
- add working search box on the home page
- allow filtering tools by category via query parameters

## Testing
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845809d6d648322a9c41c120d4c9d88