### PR TITLE
Add kubernetes manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,15 @@ backend (NestJS) and frontend (Next.js) applications.
 
 Each project contains its own `README.md` with instructions on how to run in
 development mode. Make sure you have Node.js and PostgreSQL installed.
+
+## Running with Kubernetes
+
+For a local Kubernetes cluster (such as **minikube** or **kind**) you can build
+the Docker images and apply the manifests from the `k8s/` folder:
+
+```bash
+docker build -t backend:local ./backend
+docker build -t frontend:local ./frontend
+kubectl apply -f k8s/
+```
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+EXPOSE 4000
+CMD ["node", "dist/main.js"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,25 @@
+# Local Kubernetes Setup
+
+This folder contains example manifests to run the application with Kubernetes using local Docker images. These steps assume you are using a local cluster such as **minikube** or **kind**.
+
+## Build images
+
+From the repository root run:
+
+```bash
+# build backend image
+docker build -t backend:local ./backend
+
+# build frontend image
+docker build -t frontend:local ./frontend
+```
+
+## Start the cluster
+
+Apply all manifests in this folder:
+
+```bash
+kubectl apply -f k8s/
+```
+
+The frontend will be exposed through the `frontend` service on port `3000` and the backend on `4000` inside the cluster.

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+      - name: backend
+        image: backend:local
+        imagePullPolicy: Never
+        env:
+        - name: DATABASE_URL
+          value: postgres://postgres:postgres@postgres:5432/saas
+        ports:
+        - containerPort: 4000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  selector:
+    app: backend
+  ports:
+    - port: 4000
+      targetPort: 4000

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: frontend:local
+        imagePullPolicy: Never
+        env:
+        - name: PORT
+          value: "3000"
+        ports:
+        - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  selector:
+    app: frontend
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15
+        env:
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: postgres
+        - name: POSTGRES_DB
+          value: saas
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: data
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432


### PR DESCRIPTION
## Summary
- add Dockerfiles for backend and frontend
- add Kubernetes manifests for postgres, backend, and frontend
- document Kubernetes setup

## Testing
- `npm run build` *(fails: Cannot find module @nestjs/common)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684587b9c3e083229415632752abdbc3