### PR TITLE
Add Helm chart deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ backend (NestJS) and frontend (Next.js) applications.
 
 Each project contains its own `README.md` with instructions on how to run in
 development mode. Make sure you have Node.js and PostgreSQL installed.
+
+## Deployment with Helm
+
+A basic Helm chart is provided in the `helm/` directory. To deploy the application to a Kubernetes cluster:
+
+```bash
+helm install saas-investigator ./helm
+```
+
+Adjust the container images and other settings in `helm/values.yaml` as needed.

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: saas-investigator
+version: 0.1.0
+appVersion: 1.0.0
+description: Helm chart for deploying the SaaS Investigator backend and frontend

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,11 @@
+# Helm Chart for SaaS Investigator
+
+This chart deploys the backend and frontend applications for the SaaS Investigator platform.
+
+## Usage
+
+```bash
+helm install saas-investigator ./helm
+```
+
+Customize values using `values.yaml` or with the `--set` flag.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "saas-investigator.name" -}}
+saas-investigator
+{{- end -}}
+
+{{- define "saas-investigator.fullname" -}}
+{{ include "saas-investigator.name" . }}
+{{- end -}}

--- a/helm/templates/backend-deployment.yaml
+++ b/helm/templates/backend-deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "saas-investigator.fullname" . }}-backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "saas-investigator.name" . }}-backend
+  template:
+    metadata:
+      labels:
+        app: {{ include "saas-investigator.name" . }}-backend
+    spec:
+      containers:
+        - name: backend
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          env:
+            - name: PORT
+              value: "{{ .Values.backend.service.port }}"
+          ports:
+            - containerPort: {{ .Values.backend.service.port }}
+          command: ["node", "server.js"]

--- a/helm/templates/backend-service.yaml
+++ b/helm/templates/backend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "saas-investigator.fullname" . }}-backend
+spec:
+  type: {{ .Values.backend.service.type }}
+  selector:
+    app: {{ include "saas-investigator.name" . }}-backend
+  ports:
+    - port: {{ .Values.backend.service.port }}
+      targetPort: {{ .Values.backend.service.port }}
+      protocol: TCP
+      name: http

--- a/helm/templates/frontend-deployment.yaml
+++ b/helm/templates/frontend-deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "saas-investigator.fullname" . }}-frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "saas-investigator.name" . }}-frontend
+  template:
+    metadata:
+      labels:
+        app: {{ include "saas-investigator.name" . }}-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          env:
+            - name: PORT
+              value: "{{ .Values.frontend.service.port }}"
+          ports:
+            - containerPort: {{ .Values.frontend.service.port }}
+          command: ["npm", "start"]

--- a/helm/templates/frontend-service.yaml
+++ b/helm/templates/frontend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "saas-investigator.fullname" . }}-frontend
+spec:
+  type: {{ .Values.frontend.service.type }}
+  selector:
+    app: {{ include "saas-investigator.name" . }}-frontend
+  ports:
+    - port: {{ .Values.frontend.service.port }}
+      targetPort: {{ .Values.frontend.service.port }}
+      protocol: TCP
+      name: http

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,16 @@
+backend:
+  image:
+    repository: node
+    tag: 18
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 4000
+frontend:
+  image:
+    repository: node
+    tag: 18
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 3000


### PR DESCRIPTION
## Summary
- add a Helm chart for backend and frontend services
- document Helm usage in the main README

## Testing
- `helm version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845889a5c4483228dcf90eee575c8ad